### PR TITLE
Add prefix to title and translate confirmation message

### DIFF
--- a/app/models/spree/google_merchant_configuration.rb
+++ b/app/models/spree/google_merchant_configuration.rb
@@ -11,6 +11,7 @@ module Spree
     #
     preference :public_domain, :string
     preference :save_to_aws, :boolean, :default =>false
+    preference :title_prefix, :string
     preference :s3_region, :string, :default =>'us-east-1'
     preference :s3_bucket, :string
 

--- a/app/views/spree/admin/google_merchant_settings/show.html.erb
+++ b/app/views/spree/admin/google_merchant_settings/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to 'Generate & transfer XML', generate_and_transfer_xml_admin_google_merchant_settings_path, method: :post, data: { confirm: 'Lista produktów w Goole Merchant Center zostanie nadpisana. Chcesz kontynuować?' }, class: 'btn-success', icon: :add, id: 'admin_generate_and_transfer_xml' %>
+  <%= button_link_to 'Generate & transfer XML', generate_and_transfer_xml_admin_google_merchant_settings_path, method: :post, data: { confirm: 'La liste de produits dans Google Merchant Center sera écrasée. Voulez-vous continuer?' }, class: 'btn-success', icon: :add, id: 'admin_generate_and_transfer_xml' %>
 <% end %>
 
 <table>

--- a/lib/spree_google_merchant/feed_builder.rb
+++ b/lib/spree_google_merchant/feed_builder.rb
@@ -187,7 +187,11 @@ module SpreeGoogleMerchant
 
         GOOGLE_MERCHANT_ATTR_MAP.each do |k, v|
           value = ad.variant.send("google_merchant_#{v}")
-          xml.tag!(k, value.to_s) if value.present?
+          if k === "title" and not Spree::GoogleMerchant::Config[:title_prefix].blank?
+            xml.tag!(k, "#{Spree::GoogleMerchant::Config[:title_prefix]} - #{value.to_s}") if value.present?
+          else
+            xml.tag!(k, value.to_s) if value.present?
+          end
         end
         build_shipping(xml, ad)
         build_adwords_labels(xml, ad)


### PR DESCRIPTION
Les modifications sont pour avoir ce genre de format sur le feed google merchant:

Mode Choc - Nom du produit

Le title_prefix est défini comme ça `Spree::GoogleMerchant::Config.set(title_prefix: 'Mode Choc')` dans le code de Mode Choc